### PR TITLE
undid function renaming

### DIFF
--- a/tracking code/MTF_export_figures.m
+++ b/tracking code/MTF_export_figures.m
@@ -1,5 +1,5 @@
-function [] = MTF_saveasures(final_tracks, tracks_tail, seq_name)
-% MTF_saveasures(final_tracks, tail_tracks)
+function [] = MTF_export_figures(final_tracks, tracks_tail, seq_name)
+% MTF_export_figures(final_tracks, tail_tracks)
 %
 % Plots the tracks resulting from the MTF tracker. The default plots are:
 %


### PR DESCRIPTION
by using replace all when changing the usage of export_fig() to saveas(), the function name MTF_export_figures() was erroneously changed to MTF_saveasures(). I corrected it.
